### PR TITLE
Correct thumb size if range and step is 1

### DIFF
--- a/src/feathers/controls/HScrollBar.hx
+++ b/src/feathers/controls/HScrollBar.hx
@@ -204,7 +204,7 @@ class HScrollBar extends BaseScrollBar {
 				this._currentThumbSkin.width = this._thumbSkinMeasurements.width;
 			}
 		} else {
-			var thumbWidth = contentWidth * this.getAdjustedPage() / range;
+			var thumbWidth = range == 1 && step == 1 ? contentWidth * .75 : contentWidth * this.getAdjustedPage() / range;
 			if (thumbWidth > 0.0) {
 				var widthOffset = contentWidth - thumbWidth;
 				if (widthOffset > thumbWidth) {

--- a/src/feathers/controls/VScrollBar.hx
+++ b/src/feathers/controls/VScrollBar.hx
@@ -205,7 +205,7 @@ class VScrollBar extends BaseScrollBar {
 				this._currentThumbSkin.height = this._thumbSkinMeasurements.height;
 			}
 		} else {
-			var thumbHeight = contentHeight * this.getAdjustedPage() / range;
+			var thumbHeight = range == 1 ? contentHeight * .75 : contentHeight * this.getAdjustedPage() / range;
 			if (thumbHeight > 0.0) {
 				var heightOffset = contentHeight - thumbHeight;
 				if (heightOffset > thumbHeight) {

--- a/src/feathers/controls/VScrollBar.hx
+++ b/src/feathers/controls/VScrollBar.hx
@@ -205,7 +205,7 @@ class VScrollBar extends BaseScrollBar {
 				this._currentThumbSkin.height = this._thumbSkinMeasurements.height;
 			}
 		} else {
-			var thumbHeight = range == 1 ? contentHeight * .75 : contentHeight * this.getAdjustedPage() / range;
+			var thumbHeight = range == 1 && step == 1 ? contentHeight * .75 : contentHeight * this.getAdjustedPage() / range;
 			if (thumbHeight > 0.0) {
 				var heightOffset = contentHeight - thumbHeight;
 				if (heightOffset > thumbHeight) {


### PR DESCRIPTION
When fixedThumbSize is false, the step is 1 and the range is 1 (max = 1, min = 0), the thumb sizes to the entire track. My changes resolve this but it feels dirty. There's probably a better way to handle this but I hope it highlights the issue and pinpoints the nature of the cause.