### PR TITLE
Fix recursive `closeListView()` call.

### DIFF
--- a/src/feathers/controls/PopUpListView.hx
+++ b/src/feathers/controls/PopUpListView.hx
@@ -609,6 +609,9 @@ class PopUpListView extends FeathersControl implements IIndexSelector implements
 		}
 		if (this._focusManager == null) {
 			this.stage.focus = this;
+			if (!this.open) {
+				return;
+			}
 		}
 		if (this.popUpAdapter != null) {
 			this.popUpAdapter.close();


### PR DESCRIPTION
Setting `focus = this` will sometimes trigger `popUpListView_listView_focusOutHandler`, which then calls `closeListView()` again. It won't recurse forever, but `listView.parent` will be null once the recursion is done, so we need to watch out for that.