### PR TITLE
FeathersControl: Improve disabledAlpha property

### DIFF
--- a/src/feathers/core/FeathersControl.hx
+++ b/src/feathers/core/FeathersControl.hx
@@ -152,10 +152,10 @@ class FeathersControl extends MeasureSprite implements IUIControl implements IVa
 			return this._enabled;
 		}
 		this._enabled = value;
-		if (this._enabled || this.disabledAlpha == null) {
+		if (this._enabled || this._disabledAlpha == null) {
 			super.alpha = this._explicitAlpha;
-		} else if (!this._enabled && this.disabledAlpha != null) {
-			super.alpha = this.disabledAlpha;
+		} else if (!this._enabled && this._disabledAlpha != null) {
+			super.alpha = this._disabledAlpha;
 		}
 		this.setInvalid(STATE);
 		if (this._enabled) {
@@ -342,22 +342,37 @@ class FeathersControl extends MeasureSprite implements IUIControl implements IVa
 
 	#if (flash && haxe_ver < 4.3) @:setter(alpha) #else override #end private function set_alpha(value:Float):#if (!flash || haxe_ver >= 4.3) Float #else Void #end {
 		this._explicitAlpha = value;
-		if (this._enabled || this.disabledAlpha == null) {
+		if (this._enabled || this._disabledAlpha == null) {
 			super.alpha = value;
 		}
 		#if (!flash || haxe_ver >= 4.3)
 		return this._explicitAlpha;
 		#end
 	}
-
+	
+	private var _disabledAlpha:Null<Float> = null;
 	/**
-		When `disabledAlpha` is not `null`, sets the `alpha` property to this
+		When `_disabledAlpha` is not `null`, sets the `alpha` property to this
 		value when the the `enabled` property is set to `false`.
 
 		@since 1.0.0
 	**/
 	@:style
-	public var disabledAlpha:Null<Float> = null;
+	public var disabledAlpha(get, set):Null<Float>;
+
+	private function get_disabledAlpha():Null<Float>
+	{
+		return this._disabledAlpha;
+	}
+
+	private function set_disabledAlpha(value:Null<Float>):Null<Float>
+	{
+		//Avoids removing the same value check in the enabled property setter
+		this._enabled = !this._enabled;
+		_disabledAlpha = value;
+		this.set_enabled(!this._enabled);
+		return this._disabledAlpha;
+	}
 
 	private var _focusManager:IFocusManager = null;
 

--- a/src/feathers/core/FeathersControl.hx
+++ b/src/feathers/core/FeathersControl.hx
@@ -352,7 +352,7 @@ class FeathersControl extends MeasureSprite implements IUIControl implements IVa
 	
 	private var _disabledAlpha:Null<Float> = null;
 	/**
-		When `_disabledAlpha` is not `null`, sets the `alpha` property to this
+		When `disabledAlpha` is not `null`, sets the `alpha` property to this
 		value when the the `enabled` property is set to `false`.
 
 		@since 1.0.0
@@ -360,17 +360,24 @@ class FeathersControl extends MeasureSprite implements IUIControl implements IVa
 	@:style
 	public var disabledAlpha(get, set):Null<Float>;
 
-	private function get_disabledAlpha():Null<Float>
-	{
+	private function get_disabledAlpha():Null<Float> {
 		return this._disabledAlpha;
 	}
 
-	private function set_disabledAlpha(value:Null<Float>):Null<Float>
-	{
-		//Avoids removing the same value check in the enabled property setter
-		this._enabled = !this._enabled;
-		_disabledAlpha = value;
-		this.set_enabled(!this._enabled);
+	private function set_disabledAlpha(value:Null<Float>):Null<Float> {
+		if (!this.setStyle("disabledAlpha")) {
+			return this._disabledAlpha;
+		}
+		// in a -final build, this forces the clearStyle
+		// function to be kept if the property is kept
+		// otherwise, it would be removed by dce
+		this._previousClearStyle = this.clearStyle_disabledAlpha;
+		this._disabledAlpha = value;
+		if (this._enabled || this._disabledAlpha == null) {
+			super.alpha = this._explicitAlpha;
+		} else if (!this._enabled && this._disabledAlpha != null) {
+			super.alpha = this._disabledAlpha;
+		}
 		return this._disabledAlpha;
 	}
 
@@ -625,6 +632,13 @@ class FeathersControl extends MeasureSprite implements IUIControl implements IVa
 		this.showFocus(false);
 		this._focusRectSkin = null;
 		return this._focusRectSkin;
+	}
+
+	@:noCompletion
+	private function clearStyle_disabledAlpha():Null<Float> {
+		this._disabledAlpha = null;
+		super.alpha = this._explicitAlpha;
+		return this._disabledAlpha;
 	}
 
 	@:noCompletion

--- a/src/feathers/core/FeathersControl.hx
+++ b/src/feathers/core/FeathersControl.hx
@@ -357,7 +357,7 @@ class FeathersControl extends MeasureSprite implements IUIControl implements IVa
 
 		@since 1.0.0
 	**/
-	@:style
+	@style
 	public var disabledAlpha(get, set):Null<Float>;
 
 	private function get_disabledAlpha():Null<Float> {


### PR DESCRIPTION
The disabledAlpha property should probably be able to be set after the enabled property while still taking effect. 

This minimal change prevents any confusion in the event someone does happen to set this property after setting the enabled property, either intentionally or coincidentally.