### PR TITLE
TextInput: Include the caretIndex property

### DIFF
--- a/src/feathers/controls/TextInput.hx
+++ b/src/feathers/controls/TextInput.hx
@@ -397,6 +397,29 @@ class TextInput extends FeathersControl implements IStateContext<TextInputState>
 		return this._text;
 	}
 
+	/**
+		The caret position of the text input.
+	**/
+	public var caretIndex(get, set):Int;
+	
+	private function get_caretIndex():Int {
+		return this.textField.caretIndex;
+	}
+	
+	private function set_caretIndex(value:Int):Int {
+		if(this.editable){
+			var len:Int = this.textField.text.length;
+			if (value < 0){
+				value = 0;
+			} else
+			if (value > len){
+				value = len;
+			}
+			this.textField.setSelection(value, value);
+		}
+		return this.textField.caretIndex;
+	}
+
 	private var _measureText:String = null;
 
 	/**


### PR DESCRIPTION
Here is a proposal for caret index. It would be nice to have access to it in many cases. I assume it is just an oversight not to include it already. Allowing to set the caret is an optional bonus.

Example requirement:

If I want to create a TextInput for an integer with a restricted number of digits, but I want to allow negative values, I need to know the caret index to ensure users can not input a dash/minus sign at an arbitrary index when typing.