### PR TITLE
When the duration is 0, the scroller.stop() should be executed once

### DIFF
--- a/src/feathers/controls/ListView.hx
+++ b/src/feathers/controls/ListView.hx
@@ -1839,6 +1839,7 @@ class ListView extends BaseScrollContainer implements IIndexSelector implements 
 		}
 
 		if (duration == 0.0) {
+			this.scroller.stop();
 			this.scroller.scrollX = targetX;
 			this.scroller.scrollY = targetY;
 		} else {


### PR DESCRIPTION
When I swipe the ListView and release the mouse, the ListView will have an update animation that continuously affects the scrollX and scrollY values. If I call a call with a duration of 0 at this time, it will result in invalidity:
```haxe
this.list_msg.scrollToIndex(this.list_msg.dataProvider.length - 1, 0);
```